### PR TITLE
Milestone 00 — Freeze the Project Spine

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# frogbed-dirty-darts
-Agentic game workflow
+# FrogBed / Dirty Darts
+
+FrogBed / Dirty Darts is a darts roguelike project built milestone-by-milestone.
+
+## Development workflow
+
+This repo uses an agentic milestone workflow:
+
+- `AGENTS.md` contains rules for AI/developer agents.
+- `docs/milestones/` contains the milestone source-of-truth files.
+- GitHub Issues are task cards for each milestone.
+- Branches are created one milestone at a time from the latest `main`.
+- Pull Requests are used to review and merge milestone work.
+
+## Architecture boundaries
+
+- `core/` = pure models, enums, IDs, board concepts
+- `systems/` = runtime game logic
+- `content/` = authored data/catalogues
+- `sim/` = simulations/manual runners/reports
+- `ui/` = display only
+- `data/` = save/schema/data files
+- `docs/` = design locks, milestone notes, decisions
+
+UI must not own game rules.
+
+## Current status
+
+The project scaffold is created. No gameplay systems are implemented yet.


### PR DESCRIPTION
## Summary

Completes Milestone 00 by documenting the project spine and architecture boundaries in the README.

## Checks

- [x] Read `AGENTS.md`
- [x] Read `docs/milestones/milestone_00.md`
- [x] No gameplay systems implemented
- [x] README documents the workflow and architecture boundaries
- [x] No later milestone features added

## Out of scope

- Board model
- Weighting
- Future dart generation
- Play detection
- Dirty darts
- Coasters
- UI

Closes #2